### PR TITLE
General fixes for origin api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+#secrets
+*.secret.*
+
 # C extensions
 *.so
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,16 @@ version: '2'
 services:
   parity:
     image: parity/parity:v2.0.5
+    #ports:
+    #- 8545:8545
+    #- 8546:8546
+    #- 30303:30303
+    #- 30303:30303/udp
     command:
     - --chain
     - tobalaba
+    - --bootnodes
+    - enode://147573f46fe9f5cc38fbe070089a31390baec5dd2827c8f2ef168833e4d0254fbee3969a02c5b9910ea5d5b23d86a6ed5eabcda17cc12007b7d9178b6c697aa5@37.120.168.56:30303
     - --log-file
     - /app/logs/parity.log
     - --db-compaction
@@ -13,6 +20,7 @@ services:
     - all
     volumes:
     - ./logs/:/app/logs/:rw
+    - ~/.local/share/io.parity.ethereum/:/root/.local/share/io.parity.ethereum/
   origin-producer:
     build: ./producer
     volumes:

--- a/producer/core/helper.py
+++ b/producer/core/helper.py
@@ -27,7 +27,7 @@ file_handler.setFormatter(formatter)
 logger = colorlog.getLogger('example')
 logger.addHandler(tty_handler)
 logger.addHandler(file_handler)
-logger.setLevel(logging.NOTSET)
+logger.setLevel(logging.DEBUG)
 
 error_log = logging.getLogger()
 error_file_handler = logging.FileHandler(PERSISTENCE + 'error.log')
@@ -62,7 +62,8 @@ def print_config(configuration_file):
         [logger.debug(prod.format(item.name, item.energy.__class__.__name__, item.carbon_emission.__class__.__name__))
          for item in configuration.production]
     if configuration.consumption is not None:
-        [logger.debug(coms.format(item.name, item.energy.__class__.__name__)) for item in configuration.consumption]
+        [logger.debug(coms.format(item.name, item.energy.__class__.__name__))
+         for item in configuration.consumption]
     return {"configuration": configuration}
 
 
@@ -71,20 +72,27 @@ def _produce(chain_file, config, item) -> bool:
         production_local_chain = dao.DiskStorage(chain_file, PERSISTENCE)
         last_local_chain_hash = production_local_chain.get_last_hash()
         last_remote_state = config.client.last_state(item.origin)
-        produced_data = dao.read_production_data(item, last_local_chain_hash, last_remote_state)
+        produced_data = dao.read_production_data(
+            item, last_local_chain_hash, last_remote_state)
         created_file = production_local_chain.add_to_chain(produced_data)
         tx_receipt = config.client.mint(produced_data.produced, item.origin)
         friendly_name = item.name
         data = produced_data.produced
+
+        logger.info(F"produced data: {produced_data}")
+
         block_number = str(tx_receipt['blockNumber'])
         msg = '[PROD] meter: {} - {} watts - {} kg of Co2 - block: {}'
         if data.is_meter_down:
-            logger.warning(msg.format(friendly_name, data.energy, data.co2_saved, block_number))
+            logger.warning(msg.format(friendly_name, data.energy,
+                                      data.co2_saved, block_number))
         else:
-            logger.info(msg.format(friendly_name, data.energy, data.co2_saved, block_number))
+            logger.info(msg.format(friendly_name, data.energy,
+                                   data.co2_saved, block_number))
         return True
     except Exception as e:
-        error_log.exception("[BOND][PROD] module: {} - stack: {}".format(item.energy.__class__.__name__, e))
+        error_log.exception(
+            "[BOND][PROD] module: {} - stack: {}".format(item.energy.__class__.__name__, e))
         return False
 
 
@@ -94,7 +102,8 @@ def print_production_results(config: Configuration, item: InputConfiguration, ch
             return
         time.sleep(300 * trial)
         if trial == 2:
-            logger.critical("[COMS][FAIL] module: {} - Check error.log".format(item.energy.__class__.__name__))
+            logger.critical(
+                "[COMS][FAIL] module: {} - Check error.log".format(item.energy.__class__.__name__))
 
 
 def _consume(chain_file, config, item):
@@ -102,7 +111,8 @@ def _consume(chain_file, config, item):
         consumption_local_chain = dao.DiskStorage(chain_file, PERSISTENCE)
         last_local_chain_hash = consumption_local_chain.get_last_hash()
         last_remote_state = config.client.last_state(item.origin)
-        consumed_data = dao.read_consumption_data(item, last_local_chain_hash, last_remote_state)
+        consumed_data = dao.read_consumption_data(
+            item, last_local_chain_hash, last_remote_state)
         created_file = consumption_local_chain.add_to_chain(consumed_data)
         tx_receipt = config.client.mint(consumed_data.consumed, item.origin)
         friendly_name = item.name
@@ -110,12 +120,15 @@ def _consume(chain_file, config, item):
         block_number = str(tx_receipt['blockNumber'])
         message = '[COMS] meter: {} - {} watts - block: {}'
         if data.is_meter_down:
-            logger.warning(message.format(friendly_name, data.energy, block_number))
+            logger.warning(message.format(
+                friendly_name, data.energy, block_number))
         else:
-            logger.info(message.format(friendly_name, data.energy, block_number))
+            logger.info(message.format(
+                friendly_name, data.energy, block_number))
         return True
     except Exception as e:
-        error_log.exception("[BOND][COMS] module: {} - stack: {}".format(item.energy.__class__.__name__, e))
+        error_log.exception(
+            "[BOND][COMS] module: {} - stack: {}".format(item.energy.__class__.__name__, e))
         return False
 
 
@@ -125,32 +138,44 @@ def print_consumption_results(config: Configuration, item: InputConfiguration, c
             return
         time.sleep(300 * trial)
         if trial == 2:
-            logger.critical("[COMS][FAIL] module: {} - Check error.log".format(item.energy.__class__.__name__))
+            logger.critical(
+                "[COMS][FAIL] module: {} - Check error.log".format(item.energy.__class__.__name__))
 
 
 def log_production(configuration: Configuration):
     fn = '{}.pkl'
-    production = [item for item in configuration.production if not issubclass(item.energy.__class__, SPGroupAPI)]
-    [print_production_results(configuration, item, fn.format(item.name)) for item in production]
+    production = [item for item in configuration.production if not issubclass(
+        item.energy.__class__, SPGroupAPI)]
+    [print_production_results(configuration, item, fn.format(
+        item.name)) for item in production]
 
 
 def log_consumption(configuration: Configuration):
     fn = '{}.pkl'
-    [print_consumption_results(configuration, item, fn.format(item.name)) for item in configuration.consumption]
+    try:
+        [print_consumption_results(configuration, item, fn.format(
+            item.name)) for item in configuration.consumption]
+    except Exception as err:
+        logger.error(err)
 
 
 def log_sp(configuration: Configuration):
     fn = '{}.pkl'
     if configuration.production:
-        production = [item for item in configuration.production if issubclass(item.energy.__class__, SPGroupAPI)]
-        [print_production_results(configuration, item, fn.format(item.name)) for item in production]
+        production = [item for item in configuration.production if issubclass(
+            item.energy.__class__, SPGroupAPI)]
+        [print_production_results(configuration, item, fn.format(
+            item.name)) for item in production]
 
 
 def schedule(kwargs):
     scheduler = sched.scheduler(time.time, time.sleep)
     today = datetime.datetime.now(pytz.utc)
-    next_hour = today + datetime.timedelta(hours=1, minutes=15)
-    scheduler.enterabs(time=time.mktime(next_hour.timetuple()), priority=2, action=log_consumption, kwargs=kwargs)
-    scheduler.enterabs(time=time.mktime(next_hour.timetuple()), priority=1, action=log_production, kwargs=kwargs)
-    logger.debug("[BOND] next data collection: {}".format(next_hour.isoformat()))
+    next_hour = today + datetime.timedelta(hours=1, seconds=0, minutes=0)
+    scheduler.enterabs(time=time.mktime(next_hour.timetuple()),
+                       priority=2, action=log_consumption, kwargs=kwargs)
+    scheduler.enterabs(time=time.mktime(next_hour.timetuple()),
+                       priority=1, action=log_production, kwargs=kwargs)
+    logger.debug("[BOND] next data collection: {}".format(
+        next_hour.isoformat()))
     scheduler.run()

--- a/producer/origin-producer.py
+++ b/producer/origin-producer.py
@@ -11,5 +11,8 @@ if __name__ == '__main__':
     configuration_file = json.loads(os.environ['PRODUCER'])
     configuration = core.print_config(configuration_file)
     while infinite:
+        print('running prod')
         core.log_production(**configuration)
+        print('log production')
         core.schedule(configuration)
+        print('schedule')


### PR DESCRIPTION
This commit fixes the following:

* time string parsing when reading origin source;

* escape for log_consumption reporting None;

* more verbosity in stdout;

* bootnode for parity